### PR TITLE
lodash defaultsDeep to assign default config instead for..in

### DIFF
--- a/main.js
+++ b/main.js
@@ -51,7 +51,7 @@ program
 
 const getid = require('./modules/getid');
 
-const config = {
+let config = {
 
     //Networking
     httpPort: 3001,                     //Порт биндинга RPC и интерфейса
@@ -151,6 +151,7 @@ const config = {
 };
 
 //*********************************************************************
+const _ = require('lodash');
 const fs = require('fs-extra');
 const Blockchain = require('./Blockchain');
 const path = require('path');
@@ -162,19 +163,15 @@ Array.prototype.remove = function (from, to) {
 
 global.PATH = {}; //object for saving paths
 global.PATH.configDir = path.dirname(program.config);
+let loadedConfig;
 
 try {
-    let loadedConfig = JSON.parse(fs.readFileSync(program.config));
-    for (let i in config) {
-        if(typeof loadedConfig[i] !== 'undefined') {
-            config[i] = loadedConfig[i];
-        }
-    }
-
+    loadedConfig = JSON.parse(fs.readFileSync(program.config));
 } catch (e) {
     logger.warning('No configure found. Using standard configuration.');
 }
 
+config = _.defaultsDeep(loadedConfig, config);
 
 if(program.writeConfig) {
     try {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "keypair": "^1.0.1",
     "level": "^6.0.0",
     "leveldown": "^5.4.1",
+    "lodash": "^4.17.15",
     "memdown": "^5.1.0",
     "moment": "^2.24.0",
     "node-rsa": "^0.4.2",


### PR DESCRIPTION
Added a dependency in package.json (lodash).
Lodash method defaultsDeep used instead of cycle for..in to assign undefined in user's configuration options to config object.